### PR TITLE
Added support for Samsung TTS Engine

### DIFF
--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -57,11 +57,11 @@ public class TTS {
                     if (tts != null) {
                         ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
                         for (int i = 0; i < engines.size() && !found; i++) {
-                            if (engines.get(i).name.equals("com.google.android.tts")) {
+                            if (engines.get(i).name.equals("com.google.android.tts")) {  // Check TTS engine from Google
                                 found = true; // Check Google TTS here.
-                            } else if (engines.get(i).name.equals("com.samsung.SMT")) {
+                            } else if (engines.get(i).name.equals("com.samsung.SMT")) {  // Check TTS engine from Samsung
                                 found = true;
-                            } // Check TTS engine from samsung here.
+                            }
                         } // Look forward to supporting more TTS engine.
                         if (!found) {
                             tts = null;
@@ -210,8 +210,7 @@ public class TTS {
                                 CustomLocale language;
                                 if (i != -1) {
                                     language = new CustomLocale(aSet.getLocale()); // Use Google TTS's .getLocale()
-                                }
-                                else {
+                                } else {
                                     language = CustomLocale.getInstance(aSet.getName()); // Use getName for SMT because Samsung use another Locale format (as "eng_USA_l03") and use Google's Locale format as its name (as "en-US-SMTl03").
                                 }
                                 ttsLanguages.add(language);

--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -53,31 +53,30 @@ public class TTS {
                         }
                     }*/
 
-                            boolean found = false;    //method 2
-                            if (tts != null) {
-                                ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
-                                for (int i = 0; i < engines.size() && !found; i++) {
-                                    if (engines.get(i).name.equals("com.google.android.tts")) {
-                                        found = true; // Check Google TTS here.
-                                    }
-                                    else if (engines.get(i).name.equals("com.samsung.SMT")) {
-                                        found = true;
-                                    } // Check TTS engine from samsung here.
-                                } // Look forward to supporting more TTS engine.
-                                if (!found) {
-                                    tts = null;
-                                    listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
-                                } else {
-                                    listener.onInit();
-                                }
-                                return;
-                            }
+                    boolean found = false;    //method 2
+                    if (tts != null) {
+                        ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
+                        for (int i = 0; i < engines.size() && !found; i++) {
+                            if (engines.get(i).name.equals("com.google.android.tts")) {
+                                found = true; // Check Google TTS here.
+                            } else if (engines.get(i).name.equals("com.samsung.SMT")) {
+                                found = true;
+                            } // Check TTS engine from samsung here.
+                        } // Look forward to supporting more TTS engine.
+                        if (!found) {
+                            tts = null;
+                            listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
+                        } else {
+                            listener.onInit();
                         }
-                        tts = null;
-                        listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
+                        return;
                     }
-                },
-                null);// "com.google.android.tts" is Google TTS and "com.samsung.SMT" is Samsung TTS
+                }
+                tts = null;
+                listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
+            }
+        },
+        null);// "com.google.android.tts" is Google TTS and "com.samsung.SMT" is Samsung TTS
     }
 
     public boolean isActive() {
@@ -196,7 +195,7 @@ public class TTS {
                     ArrayList<CustomLocale> ttsLanguages = new ArrayList<>();
                     Set<Voice> set = tempTts.getVoices();
                     SharedPreferences sharedPreferences = context.getSharedPreferences("default", Context.MODE_PRIVATE);
-                    boolean qualityLow = sharedPreferences.getBoolean("languagesQualityLow", true); // Change default to true otherwise Japanese won't work by default
+                    boolean qualityLow = sharedPreferences.getBoolean("languagesQualityLow", false);
                     int quality;
                     if (qualityLow) {
                         quality = Voice.QUALITY_VERY_LOW;
@@ -206,9 +205,7 @@ public class TTS {
                     if (set != null) {
                         // we filter the languages that have a tts that reflects the quality characteristics we want
                         for (Voice aSet : set) {
-                            int voice_quality = aSet.getQuality();
-                            int quality_thresh = quality;
-                            if (voice_quality >= quality_thresh && !aSet.getFeatures().contains("legacySetLanguageVoice")) { //
+                            if (aSet.getQuality() >= quality && !aSet.getFeatures().contains("legacySetLanguageVoice")) { //
                                 int i = aSet.getLocale().toString().indexOf("-");
                                 CustomLocale language;
                                 if (i != -1) {

--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -200,7 +200,7 @@ public class TTS {
                     if (qualityLow) {
                         quality = Voice.QUALITY_VERY_LOW;
                     } else {
-                        quality = Voice.QUALITY_HIGH;
+                        quality = Voice.QUALITY_NORMAL;
                     }
                     if (set != null) {
                         // we filter the languages that have a tts that reflects the quality characteristics we want

--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -58,12 +58,12 @@ public class TTS {
                                 ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
                                 for (int i = 0; i < engines.size() && !found; i++) {
                                     if (engines.get(i).name.equals("com.google.android.tts")) {
-                                        found = true;
+                                        found = true; // Check Google TTS here.
                                     }
                                     else if (engines.get(i).name.equals("com.samsung.SMT")) {
                                         found = true;
-                                    }
-                                }
+                                    } // Check TTS engine from samsung here.
+                                } // Look forward to supporting more TTS engine.
                                 if (!found) {
                                     tts = null;
                                     listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
@@ -212,10 +212,10 @@ public class TTS {
                                 int i = aSet.getLocale().toString().indexOf("-");
                                 CustomLocale language;
                                 if (i != -1) {
-                                    language = new CustomLocale(aSet.getLocale());
+                                    language = new CustomLocale(aSet.getLocale()); // Use Google TTS's .getLocale()
                                 }
                                 else {
-                                    language = CustomLocale.getInstance(aSet.getName());
+                                    language = CustomLocale.getInstance(aSet.getName()); // Use getName for SMT because Samsung use another Locale format (as "eng_USA_l03") and use Google's Locale format as its name (as "en-US-SMTl03").
                                 }
                                 ttsLanguages.add(language);
                             }

--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -53,27 +53,31 @@ public class TTS {
                         }
                     }*/
 
-                    boolean found = false;    //method 2
-                    if (tts != null) {
-                        ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
-                        for (int i = 0; i < engines.size() && !found; i++) {
-                            if (engines.get(i).name.equals("com.google.android.tts")) {
-                                found = true;
+                            boolean found = false;    //method 2
+                            if (tts != null) {
+                                ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
+                                for (int i = 0; i < engines.size() && !found; i++) {
+                                    if (engines.get(i).name.equals("com.google.android.tts")) {
+                                        found = true;
+                                    }
+                                    else if (engines.get(i).name.equals("com.samsung.SMT")) {
+                                        found = true;
+                                    }
+                                }
+                                if (!found) {
+                                    tts = null;
+                                    listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
+                                } else {
+                                    listener.onInit();
+                                }
+                                return;
                             }
                         }
-                        if (!found) {
-                            tts = null;
-                            listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
-                        } else {
-                            listener.onInit();
-                        }
-                        return;
+                        tts = null;
+                        listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
                     }
-                }
-                tts = null;
-                listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
-            }
-        }, "com.google.android.tts");
+                },
+                null);// "com.google.android.tts");
     }
 
     public boolean isActive() {
@@ -192,7 +196,7 @@ public class TTS {
                     ArrayList<CustomLocale> ttsLanguages = new ArrayList<>();
                     Set<Voice> set = tempTts.getVoices();
                     SharedPreferences sharedPreferences = context.getSharedPreferences("default", Context.MODE_PRIVATE);
-                    boolean qualityLow = sharedPreferences.getBoolean("languagesQualityLow", false);
+                    boolean qualityLow = sharedPreferences.getBoolean("languagesQualityLow", true); // Change default to true otherwise Japanese won't work by default
                     int quality;
                     if (qualityLow) {
                         quality = Voice.QUALITY_VERY_LOW;
@@ -202,8 +206,17 @@ public class TTS {
                     if (set != null) {
                         // we filter the languages that have a tts that reflects the quality characteristics we want
                         for (Voice aSet : set) {
-                            if (aSet.getQuality() >= quality && !aSet.getFeatures().contains("legacySetLanguageVoice")) {
-                                CustomLocale language = new CustomLocale(aSet.getLocale());
+                            int voice_quality = aSet.getQuality();
+                            int quality_thresh = quality;
+                            if (voice_quality >= quality_thresh && !aSet.getFeatures().contains("legacySetLanguageVoice")) { //
+                                int i = aSet.getLocale().toString().indexOf("-");
+                                CustomLocale language;
+                                if (i != -1) {
+                                    language = new CustomLocale(aSet.getLocale());
+                                }
+                                else {
+                                    language = CustomLocale.getInstance(aSet.getName());
+                                }
                                 ttsLanguages.add(language);
                             }
                         }


### PR DESCRIPTION
Hello,

Thank you so much for the awesome offline realtime translator app. It is very convenient and helpful even without text-to-speech services. I tried to modify the "[app/src/main/java/nie/translator/rtranslator/tools/TTS.java](https://github.com/JingziC/RTranslator_Samsung/blob/v2.00_add_SMT/app/src/main/java/nie/translator/rtranslator/tools/TTS.java)" to support the Samsung TTS engine in this app and tested on the Samsung Galaxy S21 with Android 14. The built app could use text-to-speech engine from Samsung successfully.

As mentioned in Issue #8 and #15, it sometimes could not load Google TTS engine thus disable text-to-speech functionality. I also encountered this bug and noticed that only Samsung's TTS engine could be loaded when importing "android.speech.tts.TextToSpeech" and the Google TTS Engine was missed (although Google TTS engine was set as the default text-to-speech output). Thus the app could not find the correct text-to-speech engine.

In the modified [TTS.java](https://github.com/JingziC/RTranslator_Samsung/blob/v2.00_add_SMT/app/src/main/java/nie/translator/rtranslator/tools/TTS.java), some lines pairing the engine and corresponding available languages were added. It is expected to support at least samsung's engine while keeping compatible with the Google TTS engine in previous program.

However, it still requires validations on other devices. The program for validation has been built in an [.apk](https://github.com/JingziC/RTranslator_Samsung/releases/tag/validation) file for a quick check and also can be built from [this branch](https://github.com/JingziC/RTranslator_Samsung/tree/v2.00_add_smt).

Available TTS Engine from "android.speech.tts.TextToSpeech" (https://github.com/JingziC/TTSLister was used to check the available tts engines on device directly):

<img src="https://github.com/niedev/RTranslator/assets/140467318/2c481839-a54f-435c-bf0b-295e86c50fda" alt="Available_TTS_Engine" width="135" height="300">