### PR TITLE
Try to add support for device's default TTS and decouple the languages supported by TTS engine and Whisper

### DIFF
--- a/app/src/main/java/nie/translator/rtranslator/Global.java
+++ b/app/src/main/java/nie/translator/rtranslator/Global.java
@@ -157,7 +157,7 @@ public class Global extends Application implements DefaultLifecycleObserver {
                     //we return only the languages compatible with the speech recognizer, the translator and the tts
                     final ArrayList<CustomLocale> compatibleLanguages = new ArrayList<>();
                     for (CustomLocale translatorLanguage : translatorLanguages) {
-                        if (CustomLocale.containsLanguage(speechRecognizerLanguages, translatorLanguage)) { // CustomLocale.containsLanguage(ttsLanguages, translatorLanguage) &&
+                        if (CustomLocale.containsLanguage(speechRecognizerLanguages, translatorLanguage)) { // remove "CustomLocale.containsLanguage(ttsLanguages, translatorLanguage) &&" to decouple TTS's list and translator's list
                             compatibleLanguages.add(translatorLanguage);
                         }
                     }

--- a/app/src/main/java/nie/translator/rtranslator/Global.java
+++ b/app/src/main/java/nie/translator/rtranslator/Global.java
@@ -157,7 +157,7 @@ public class Global extends Application implements DefaultLifecycleObserver {
                     //we return only the languages compatible with the speech recognizer, the translator and the tts
                     final ArrayList<CustomLocale> compatibleLanguages = new ArrayList<>();
                     for (CustomLocale translatorLanguage : translatorLanguages) {
-                        if (CustomLocale.containsLanguage(ttsLanguages, translatorLanguage) && CustomLocale.containsLanguage(speechRecognizerLanguages, translatorLanguage)) {
+                        if (CustomLocale.containsLanguage(speechRecognizerLanguages, translatorLanguage)) { // CustomLocale.containsLanguage(ttsLanguages, translatorLanguage) &&
                             compatibleLanguages.add(translatorLanguage);
                         }
                     }

--- a/app/src/main/java/nie/translator/rtranslator/Global.java
+++ b/app/src/main/java/nie/translator/rtranslator/Global.java
@@ -117,34 +117,6 @@ public class Global extends Application implements DefaultLifecycleObserver {
         });
     }
 
-    public void getLanguages(final boolean recycleResult, final GetLocalesListListener responseListener) {
-        if (recycleResult && !languages.isEmpty()) {
-            responseListener.onSuccess(languages);
-        } else {
-            TTS.getSupportedLanguages(this, new TTS.SupportedLanguagesListener() {
-                @Override
-                public void onLanguagesListAvailable(ArrayList<CustomLocale> ttsLanguages) {
-                    ArrayList<CustomLocale> translatorLanguages = Translator.getSupportedLanguages(Global.this, Translator.NLLB);
-                    ArrayList<CustomLocale> speechRecognizerLanguages = Recognizer.getSupportedLanguages(Global.this);
-                    //we return only the languages compatible with the speech recognizer, the translator and the tts
-                    final ArrayList<CustomLocale> compatibleLanguages = new ArrayList<>();
-                    for (CustomLocale translatorLanguage : translatorLanguages) {
-                        if (CustomLocale.containsLanguage(ttsLanguages, translatorLanguage) && CustomLocale.containsLanguage(speechRecognizerLanguages, translatorLanguage)) {
-                            compatibleLanguages.add(translatorLanguage);
-                        }
-                    }
-                    languages = compatibleLanguages;
-                    responseListener.onSuccess(compatibleLanguages);
-                }
-
-                @Override
-                public void onError(int reason) {
-                    responseListener.onFailure(new int[]{reason}, 0);
-                }
-            });
-        }
-    }
-
     public void getLanguages(final boolean recycleResult, boolean ignoreTTSError,final GetLocalesListListener responseListener) {
         if (recycleResult && !languages.isEmpty()) {
             responseListener.onSuccess(languages);

--- a/app/src/main/java/nie/translator/rtranslator/Global.java
+++ b/app/src/main/java/nie/translator/rtranslator/Global.java
@@ -129,7 +129,7 @@ public class Global extends Application implements DefaultLifecycleObserver {
                     //we return only the languages compatible with the speech recognizer, the translator and the tts
                     final ArrayList<CustomLocale> compatibleLanguages = new ArrayList<>();
                     for (CustomLocale translatorLanguage : translatorLanguages) {
-                        if (CustomLocale.containsLanguage(speechRecognizerLanguages, translatorLanguage)) { // remove "CustomLocale.containsLanguage(ttsLanguages, translatorLanguage) &&" to decouple TTS's list and translator's list
+                        if (CustomLocale.containsLanguage(speechRecognizerLanguages, translatorLanguage)) {
                             compatibleLanguages.add(translatorLanguage);
                         }
                     }

--- a/app/src/main/java/nie/translator/rtranslator/tools/CustomLocale.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/CustomLocale.java
@@ -157,7 +157,7 @@ public class CustomLocale implements Comparable<CustomLocale>, Serializable {
         if (containsLanguage(TTS.ttsLanguages, CustomLocale.getInstance(locale.getLanguage()))) {
             return locale.getDisplayName();
         } else {
-            return locale.getDisplayName()+" (No TTS)"; // Notice that users cannot use TTS for this language.
+            return locale.getDisplayName()+" (no TTS)"; // Notice that users cannot use TTS for this language.
         }
     }
 

--- a/app/src/main/java/nie/translator/rtranslator/tools/CustomLocale.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/CustomLocale.java
@@ -154,7 +154,11 @@ public class CustomLocale implements Comparable<CustomLocale>, Serializable {
     }
 
     public String getDisplayName() {
-        return locale.getDisplayName();
+        if (containsLanguage(TTS.ttsLanguages, CustomLocale.getInstance(locale.getLanguage()))) {
+            return locale.getDisplayName();
+        } else {
+            return locale.getDisplayName()+" (No Text-to-Speech)"; // Notice that users cannot use TTS for this language.
+        }
     }
 
     public String getDisplayName(Locale locale) {

--- a/app/src/main/java/nie/translator/rtranslator/tools/CustomLocale.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/CustomLocale.java
@@ -157,7 +157,7 @@ public class CustomLocale implements Comparable<CustomLocale>, Serializable {
         if (containsLanguage(TTS.ttsLanguages, CustomLocale.getInstance(locale.getLanguage()))) {
             return locale.getDisplayName();
         } else {
-            return locale.getDisplayName()+" (No Text-to-Speech)"; // Notice that users cannot use TTS for this language.
+            return locale.getDisplayName()+" (No TTS)"; // Notice that users cannot use TTS for this language.
         }
     }
 

--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -53,38 +53,38 @@ public class TTS {
                         }
                     }*/
 
-                            boolean found = false;    //method 2
-                            if (tts != null) { // remove previous engine check
-//                                ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
-//                                for (int i = 0; i < engines.size() && !found; i++) {
-//                                    switch (engines.get(i).name) {
-//                                        case "com.google.android.tts":
-//                                            found = true; // Check Google TTS here.
-//                                            break;
-//                                        case "com.samsung.SMT": // Check Samsung TTS here.
-//                                            found = true;
-//                                            break;
-//                                        case "com.huawei.hiai": // Check Huawei TTS here.
-//                                            found = true;
-//                                            break;
-//                                    }
-//                                } // Look forward to supporting more TTS engine.
-//                                if (!found) {
-//                                    tts = null;
-//                                    listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
-//                                } else {
-//                                    listener.onInit();
-//                                }
-//                                return;
+                        /*boolean found = false;*/    //method 2
+                        if (tts != null) {
+                            /*ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
+                            for (int i = 0; i < engines.size() && !found; i++) {
+                                switch (engines.get(i).name) {
+                                    case "com.google.android.tts":
+                                        found = true; // Check Google TTS here.
+                                        break;
+                                    case "com.samsung.SMT": // Check Samsung TTS here.
+                                        found = true;
+                                        break;
+                                    case "com.huawei.hiai": // Check Huawei TTS here.
+                                        found = true;
+                                        break;
+                                }
+                            } // Look forward to supporting more TTS engine.
+                            if (!found) {
+                                tts = null;
+                                listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
+                            } else {
                                 listener.onInit();
-                                return; // Set TTS to the default TTS directly.
                             }
+                            return;*/
+                            listener.onInit();
+                            return; // Set TTS to the default TTS directly.
                         }
-                        tts = null;
-                        listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
                     }
-                },
-                null);// use default TTS when this is null
+                    tts = null;
+                    listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
+                }
+            },
+            null);// use default TTS when this is null
     }
 
     public boolean isActive() {
@@ -211,7 +211,7 @@ public class TTS {
                     } else {
                         quality = Voice.QUALITY_NORMAL;
                     }
-                    boolean found_language = false; // if there is available languages; keep false if our code cannot get its name
+                    boolean foundLanguage = false; // if there is available languages; keep false if our code cannot get its name
                     if (set != null) {
                         // we filter the languages that have a tts that reflects the quality characteristics we want
                         for (Voice aSet : set) {
@@ -220,16 +220,16 @@ public class TTS {
                                 CustomLocale language;
                                 if (i != -1) {
                                     language = new CustomLocale(aSet.getLocale()); // Use .getLocale() for google
-                                    found_language = true;
+                                    foundLanguage = true;
                                 } else {
                                     language = CustomLocale.getInstance(aSet.getName()); // Use .getName() for samsung/huawei (maybe others also)
-                                    found_language = true;
+                                    foundLanguage = true;
                                 }
                                 ttsLanguages.add(language);
                             }
                         }
                     }
-                    if (found_language) { // start TTS if the above lines find at least 1 supported language
+                    if (foundLanguage) { // start TTS if the above lines find at least 1 supported language
                         mainHandler.post(new Runnable() {
                             @Override
                             public void run() {

--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -53,38 +53,38 @@ public class TTS {
                         }
                     }*/
 
-                        /*boolean found = false;*/    //method 2
-                        if (tts != null) {
-                            /*ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
-                            for (int i = 0; i < engines.size() && !found; i++) {
-                                switch (engines.get(i).name) {
-                                    case "com.google.android.tts":
-                                        found = true; // Check Google TTS here.
-                                        break;
-                                    case "com.samsung.SMT": // Check Samsung TTS here.
-                                        found = true;
-                                        break;
-                                    case "com.huawei.hiai": // Check Huawei TTS here.
-                                        found = true;
-                                        break;
-                                }
-                            } // Look forward to supporting more TTS engine.
-                            if (!found) {
-                                tts = null;
-                                listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
-                            } else {
-                                listener.onInit();
+                    /*boolean found = false;*/    //method 2
+                    if (tts != null) {
+                        /*ArrayList<TextToSpeech.EngineInfo> engines = new ArrayList<>(tts.getEngines());
+                        for (int i = 0; i < engines.size() && !found; i++) {
+                            switch (engines.get(i).name) {
+                                case "com.google.android.tts":
+                                    found = true; // Check Google TTS here.
+                                    break;
+                                case "com.samsung.SMT": // Check Samsung TTS here.
+                                    found = true;
+                                    break;
+                                case "com.huawei.hiai": // Check Huawei TTS here.
+                                    found = true;
+                                    break;
                             }
-                            return;*/
+                        } // Look forward to supporting more TTS engine.
+                        if (!found) {
+                            tts = null;
+                            listener.onError(ErrorCodes.MISSING_GOOGLE_TTS);
+                        } else {
                             listener.onInit();
-                            return; // Set TTS to the default TTS directly.
                         }
+                        return;*/
+                        listener.onInit();
+                        return; // Set TTS to the default TTS directly.
                     }
-                    tts = null;
-                    listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
                 }
-            },
-            null);// use default TTS when this is null
+                tts = null;
+                listener.onError(ErrorCodes.GOOGLE_TTS_ERROR);
+            }
+        },
+        null);// use default TTS when this is null
     }
 
     public boolean isActive() {
@@ -181,7 +181,7 @@ public class TTS {
         }
     }
 
-    public static ArrayList<CustomLocale> ttsLanguages = new ArrayList<>(); // Change TTS language list to public
+    public static ArrayList<CustomLocale> ttsLanguages = new ArrayList<>();
 
     private static class GetSupportedLanguageRunnable implements Runnable {
         private SupportedLanguagesListener responseListener;

--- a/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/TTS.java
@@ -63,6 +63,9 @@ public class TTS {
                                     else if (engines.get(i).name.equals("com.samsung.SMT")) {
                                         found = true;
                                     } // Check TTS engine from samsung here.
+                                    else if (engines.get(i).name.equals("com.huawei.hiai")) {
+                                        found = true;
+                                    } // Check TTS engine from huawei here.
                                 } // Look forward to supporting more TTS engine.
                                 if (!found) {
                                     tts = null;
@@ -174,6 +177,8 @@ public class TTS {
         }
     }
 
+    public static ArrayList<CustomLocale> ttsLanguages = new ArrayList<>();
+
     private static class GetSupportedLanguageRunnable implements Runnable {
         private SupportedLanguagesListener responseListener;
         private Context context;
@@ -193,7 +198,6 @@ public class TTS {
             tempTts = new TTS((context), new TTS.InitListener() {    // tts initialization (to be improved, automatic package installation)
                 @Override
                 public void onInit() {
-                    ArrayList<CustomLocale> ttsLanguages = new ArrayList<>();
                     Set<Voice> set = tempTts.getVoices();
                     SharedPreferences sharedPreferences = context.getSharedPreferences("default", Context.MODE_PRIVATE);
                     boolean qualityLow = sharedPreferences.getBoolean("languagesQualityLow", true); // Change default to true otherwise Japanese won't work by default

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/ConversationService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/ConversationService.java
@@ -166,7 +166,7 @@ public class ConversationService extends VoiceTranslationService {
                         translator.translateMessage(conversationMessage, result, TRANSLATOR_BEAM_SIZE, new Translator.TranslateMessageListener() {
                             @Override
                             public void onTranslatedMessage(ConversationMessage conversationMessage, long messageID, boolean isFinal) {
-                                if(isFinal && TTS.ttsLanguages.contains(conversationMessage.getPayload().getLanguage())) {
+                                if(isFinal && TTS.ttsLanguages.contains(conversationMessage.getPayload().getLanguage())) { // check if the language can be speak
                                     speak(conversationMessage.getPayload().getText(), conversationMessage.getPayload().getLanguage());
                                 }
                                 message.setText(conversationMessage.getPayload().getText());   // updating the text with the new translated text (and without the language code)

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/ConversationService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/ConversationService.java
@@ -25,6 +25,7 @@ import androidx.annotation.NonNull;
 import nie.translator.rtranslator.Global;
 import nie.translator.rtranslator.tools.BluetoothHeadsetUtils;
 import nie.translator.rtranslator.tools.CustomLocale;
+import nie.translator.rtranslator.tools.TTS;
 import nie.translator.rtranslator.tools.Tools;
 import nie.translator.rtranslator.tools.gui.messages.GuiMessage;
 import nie.translator.rtranslator.tools.gui.peers.GuiPeer;
@@ -165,7 +166,7 @@ public class ConversationService extends VoiceTranslationService {
                         translator.translateMessage(conversationMessage, result, TRANSLATOR_BEAM_SIZE, new Translator.TranslateMessageListener() {
                             @Override
                             public void onTranslatedMessage(ConversationMessage conversationMessage, long messageID, boolean isFinal) {
-                                if(isFinal) {
+                                if(isFinal && TTS.ttsLanguages.contains(conversationMessage.getPayload().getLanguage())) {
                                     speak(conversationMessage.getPayload().getText(), conversationMessage.getPayload().getLanguage());
                                 }
                                 message.setText(conversationMessage.getPayload().getText());   // updating the text with the new translated text (and without the language code)

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/ConversationService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/ConversationService.java
@@ -166,7 +166,7 @@ public class ConversationService extends VoiceTranslationService {
                         translator.translateMessage(conversationMessage, result, TRANSLATOR_BEAM_SIZE, new Translator.TranslateMessageListener() {
                             @Override
                             public void onTranslatedMessage(ConversationMessage conversationMessage, long messageID, boolean isFinal) {
-                                if(isFinal && TTS.ttsLanguages.contains(conversationMessage.getPayload().getLanguage())) { // check if the language can be speak
+                                if(isFinal && CustomLocale.containsLanguage(TTS.ttsLanguages, conversationMessage.getPayload().getLanguage())) { // check if the language can be speak
                                     speak(conversationMessage.getPayload().getText(), conversationMessage.getPayload().getLanguage());
                                 }
                                 message.setText(conversationMessage.getPayload().getText());   // updating the text with the new translated text (and without the language code)

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
@@ -19,7 +19,6 @@ package nie.translator.rtranslator.voice_translation._walkie_talkie_mode._walkie
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-
 import androidx.annotation.NonNull;
 import java.util.ArrayList;
 
@@ -174,7 +173,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
         firstResultTranslateListener = new Translator.TranslateListener() {
             @Override
             public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
-                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) { // check if the text can be speak
+                if(isFinal && CustomLocale.containsLanguage(TTS.ttsLanguages, languageOfText)) { // check if the text can be speak
                     speak(text, languageOfText);
                 }
                 GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, true, isFinal);
@@ -201,7 +200,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
         secondResultTranslateListener = new Translator.TranslateListener() {
             @Override
             public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
-                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) { // check if the language can be speak
+                if(isFinal && CustomLocale.containsLanguage(TTS.ttsLanguages, languageOfText)) { // check if the text can be speak
                     speak(text, languageOfText);
                 }
                 GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, false, isFinal);

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import nie.translator.rtranslator.Global;
 import nie.translator.rtranslator.tools.CustomLocale;
 import nie.translator.rtranslator.tools.ErrorCodes;
+import nie.translator.rtranslator.tools.TTS;
 import nie.translator.rtranslator.tools.Tools;
 import nie.translator.rtranslator.tools.gui.messages.GuiMessage;
 import nie.translator.rtranslator.voice_translation.VoiceTranslationService;
@@ -173,7 +174,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
         firstResultTranslateListener = new Translator.TranslateListener() {
             @Override
             public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
-                if(isFinal) {
+                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) {
                     speak(text, languageOfText);
                 }
                 GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, true, isFinal);
@@ -181,7 +182,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
                 // we save every new message in the exchanged messages so that the fragment can restore them
                 WalkieTalkieService.super.addOrUpdateMessage(message);
                 //if the tts is not active we restart the mic here
-                if(tts == null || !tts.isActive() || isAudioMute){
+                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){
                     startVoiceRecorder();
                     notifyMicProgrammaticallyStarted();
                 }
@@ -200,7 +201,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
         secondResultTranslateListener = new Translator.TranslateListener() {
             @Override
             public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
-                if(isFinal) {
+                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) {
                     speak(text, languageOfText);
                 }
                 GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, false, isFinal);
@@ -208,7 +209,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
                 // we save every new message in the exchanged messages so that the fragment can restore them
                 WalkieTalkieService.super.addOrUpdateMessage(message);
                 //if the tts is not active we restart the mic here
-                if(tts == null || !tts.isActive() || isAudioMute){
+                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){
                     startVoiceRecorder();
                     notifyMicProgrammaticallyStarted();
                 }

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
@@ -181,7 +181,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
                 // we save every new message in the exchanged messages so that the fragment can restore them
                 WalkieTalkieService.super.addOrUpdateMessage(message);
                 //if the tts is not active we restart the mic here
-                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){ // initialize to receive next text
+                if(tts == null || !CustomLocale.containsLanguage(TTS.ttsLanguages, languageOfText) || !tts.isActive() || isAudioMute){
                     startVoiceRecorder();
                     notifyMicProgrammaticallyStarted();
                 }
@@ -208,7 +208,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
                 // we save every new message in the exchanged messages so that the fragment can restore them
                 WalkieTalkieService.super.addOrUpdateMessage(message);
                 //if the tts is not active we restart the mic here
-                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){ // initialize to receive next text
+                if(tts == null || !CustomLocale.containsLanguage(TTS.ttsLanguages, languageOfText) || !tts.isActive() || isAudioMute){
                     startVoiceRecorder();
                     notifyMicProgrammaticallyStarted();
                 }

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
@@ -174,7 +174,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
         firstResultTranslateListener = new Translator.TranslateListener() {
             @Override
             public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
-                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) {
+                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) { // check if the text can be speak
                     speak(text, languageOfText);
                 }
                 GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, true, isFinal);
@@ -182,7 +182,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
                 // we save every new message in the exchanged messages so that the fragment can restore them
                 WalkieTalkieService.super.addOrUpdateMessage(message);
                 //if the tts is not active we restart the mic here
-                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){
+                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){ // initialize to receive next text
                     startVoiceRecorder();
                     notifyMicProgrammaticallyStarted();
                 }
@@ -201,7 +201,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
         secondResultTranslateListener = new Translator.TranslateListener() {
             @Override
             public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
-                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) {
+                if(isFinal && TTS.ttsLanguages.contains(languageOfText)) { // check if the language can be speak
                     speak(text, languageOfText);
                 }
                 GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, false, isFinal);
@@ -209,7 +209,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
                 // we save every new message in the exchanged messages so that the fragment can restore them
                 WalkieTalkieService.super.addOrUpdateMessage(message);
                 //if the tts is not active we restart the mic here
-                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){
+                if(tts == null || !TTS.ttsLanguages.contains(languageOfText) || !tts.isActive() || isAudioMute){ // initialize to receive next text
                     startVoiceRecorder();
                     notifyMicProgrammaticallyStarted();
                 }


### PR DESCRIPTION
# Add support for Huawei's TTS and decouple the languages supported by TTS engine and Whisper

Hello,

Thank you for maintaining this project. The project has been very useful for me. I installed the latest version to a Huawei device with HarmonyOS 4.2.0 but it could not detect Huawei's TTS engine as [what happened on Samsung previously](https://github.com/niedev/RTranslator/pull/24). Besides, I noticed that the list of languages only included the languages supported by both TTS and Whisper when it detected the TTS engine. However, users including me may expect to use only the Whisper's translation even the Google, Samsung or Huawei's TTS are not available because the supported languages in TTS sometimes are limited.

To address these issues, I have made the following modifications:
- Modified [TTS.java](https://github.com/JingziC/RTranslator_Samsung/blob/e38ff5a66dcd47716713eabd19405c318fa2d42d/app/src/main/java/nie/translator/rtranslator/tools/TTS.java) to load device's default TTS engine and check if the voices can be used;
- Decoupled the lists from Whisper and TTS by modifying several lines to save the TTS's language list in [TTS.java](https://github.com/JingziC/RTranslator_Samsung/blob/e38ff5a66dcd47716713eabd19405c318fa2d42d/app/src/main/java/nie/translator/rtranslator/tools/TTS.java), some lines in [Global.java](https://github.com/JingziC/RTranslator_Samsung/blob/v2.00_add_hiai/app/src/main/java/nie/translator/rtranslator/Global.java) to get the "compatibleLanguages" supported by whisper;
-  Modified if conditions in [ConversationService.java](https://github.com/JingziC/RTranslator_Samsung/blob/e38ff5a66dcd47716713eabd19405c318fa2d42d/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/ConversationService.java) and [WalkieTalkieService.java](https://github.com/JingziC/RTranslator_Samsung/blob/e38ff5a66dcd47716713eabd19405c318fa2d42d/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java) to avoid speaking from incompatible TTS engines such as trying to speaking Japanese using Chinese TTS...
- Modified getDisplayName() in [CustomLocale.java](https://github.com/JingziC/RTranslator_Samsung/blob/v2.00_add_hiai/app/src/main/java/nie/translator/rtranslator/tools/CustomLocale.java) to display if the language is available in TTS.

The modifications were tested on a Huawei device with HarmonyOS 4.2.0 (com.huawei.hiai) and and a Samsung device with Android 14 (com.samsung.SMT). The built app looks good for me on both devices. However I did not have a chance to test on other platforms. The [.apk](https://github.com/JingziC/RTranslator_Samsung/releases/tag/Validation_v3) prerelease of this version is avaliable and can also be built from the [branch](https://github.com/JingziC/RTranslator_Samsung/tree/v2.00_add_hiai).

The updated language list displayed on Samsung with Samsung's TTS is as follows.

<img src="https://github.com/niedev/RTranslator/assets/140467318/a7dbb59b-89f3-4f7b-b831-53b370e71fa1" alt="RTranslator Language List" width="200"/>
