### PR TITLE
Add a toggle in the settings to enable or disable this feature showing original transcriptions beyond the translation. Implement the feature showing both the original text and translated text in WalkieTalkie and Conversation Mode. So the user can verify if their speeches are recognized correctly.

### DIFF
--- a/app/src/main/java/nie/translator/rtranslator/bluetooth/Message.java
+++ b/app/src/main/java/nie/translator/rtranslator/bluetooth/Message.java
@@ -51,6 +51,7 @@ public class Message implements Parcelable, Cloneable {
     private Peer receiver;  //if is null the message will be sent to all connected peers
     private String header;  // mandatory length: 1
     private byte[] data;
+    private String textToTranslate;
 
     /**
      * @param context a context
@@ -69,6 +70,12 @@ public class Message implements Parcelable, Cloneable {
      * @param text the text of the message (it will be sent by sendMessage)
      */
     public Message(Context context, @NonNull String text) {
+        this.context = context;
+        this.data = text.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public Message(String textToTranslate, Context context, @NonNull String text) {
+        this.textToTranslate = textToTranslate;
         this.context = context;
         this.data = text.getBytes(StandardCharsets.UTF_8);
     }
@@ -311,5 +318,13 @@ public class Message implements Parcelable, Cloneable {
         parcel.writeParcelable(sender, i);
         parcel.writeString(header);
         parcel.writeByteArray(this.data);
+    }
+
+    public String getTextToTranslate() {
+        return textToTranslate;
+    }
+
+    public void setTextToTranslate(String textToTranslate) {
+        this.textToTranslate = textToTranslate;
     }
 }

--- a/app/src/main/java/nie/translator/rtranslator/settings/SettingsFragment.java
+++ b/app/src/main/java/nie/translator/rtranslator/settings/SettingsFragment.java
@@ -60,6 +60,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     private SettingsActivity activity;
     private UserNamePreference userNamePreference;
     private SupportLanguagesQuality supportLanguagesQualityPreference;
+
+    private ShowOriginalTranscriptionMsgPreference showOriginalTranscriptionMsgPreference;
     private SupportTtsQualityPreference supportTtsQualityPreference;
     private LanguagePreference languagePreference;
 
@@ -160,6 +162,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         // language support option with low quality initialization
         supportLanguagesQualityPreference = (SupportLanguagesQuality) findPreference("languagesNNQualityLow");
         supportLanguagesQualityPreference.setFragment(this);
+
+        showOriginalTranscriptionMsgPreference = (ShowOriginalTranscriptionMsgPreference) findPreference("ShowOriginalTranscriptionMsgPreference");
+        showOriginalTranscriptionMsgPreference.setFragment(this);
+
 
         // language support option with low quality tts initialization
         supportTtsQualityPreference = (SupportTtsQualityPreference) findPreference("languagesQualityLow");

--- a/app/src/main/java/nie/translator/rtranslator/settings/ShowOriginalTranscriptionMsgPreference.java
+++ b/app/src/main/java/nie/translator/rtranslator/settings/ShowOriginalTranscriptionMsgPreference.java
@@ -1,0 +1,64 @@
+package nie.translator.rtranslator.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+import androidx.preference.SwitchPreference;
+
+import java.util.ArrayList;
+
+import nie.translator.rtranslator.Global;
+import nie.translator.rtranslator.tools.CustomLocale;
+import nie.translator.rtranslator.tools.ErrorCodes;
+import nie.translator.rtranslator.voice_translation.neural_networks.translation.Translator;
+
+public class ShowOriginalTranscriptionMsgPreference extends SwitchPreference {
+    private SettingsFragment fragment;
+    private Translator translator;
+    private Global global;
+    private SettingsActivity activity;
+
+    public ShowOriginalTranscriptionMsgPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public ShowOriginalTranscriptionMsgPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public ShowOriginalTranscriptionMsgPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ShowOriginalTranscriptionMsgPreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        //translator = new Translator((Global) fragment.requireActivity().getApplication(), Translator.MADLAD_CACHE);
+        setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if(global != null) {
+                    final SharedPreferences sharedPreferences = global.getSharedPreferences("default", Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPreferences.edit();
+                    editor.putBoolean("ShowOriginalTranscriptionMsgPreference", (Boolean) newValue);
+                    editor.apply();
+                }
+                return true;
+            }
+        });
+    }
+
+    public void setFragment(@NonNull SettingsFragment fragment) {
+        this.fragment = fragment;
+        this.activity = (SettingsActivity) fragment.requireActivity();
+        this.global = (Global) activity.getApplication();
+    }
+}

--- a/app/src/main/java/nie/translator/rtranslator/tools/ImageActivity.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/ImageActivity.java
@@ -53,7 +53,7 @@ public class ImageActivity extends Activity {
         messages.add(new GuiMessage(new Message(this, new Peer(null, "Carlos11", true), "m", "Je vais bien"), false, true));
         messages.add(new GuiMessage(new Message(this, "m", "Moi aussi"), true, true));*/
 
-        mAdapter = new MessagesAdapter(messages, new MessagesAdapter.Callback() {
+        mAdapter = new MessagesAdapter(messages, this.getApplication(), new MessagesAdapter.Callback() {
             @Override
             public void onFirstItemAdded() {
                 mRecyclerView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/nie/translator/rtranslator/tools/gui/messages/MessagesAdapter.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/gui/messages/MessagesAdapter.java
@@ -16,6 +16,8 @@
 
 package nie.translator.rtranslator.tools.gui.messages;
 
+import android.app.Application;
+import android.content.Context;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -30,6 +32,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
 
+import nie.translator.rtranslator.Global;
 import nie.translator.rtranslator.R;
 
 /** Is used to connect to the RecycleView, which functions as a ListView, a list of strings, which will be inserted in the ViewHolder layout and this will be inserted in the list**/
@@ -40,7 +43,9 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     private ArrayList<GuiMessage> mResults = new ArrayList<>();
     private Callback callback;
 
-    public MessagesAdapter(ArrayList<GuiMessage> messages, @NonNull Callback callback) {
+    private static boolean showOriginalTranscriptionMsg;
+
+    public MessagesAdapter(ArrayList<GuiMessage> messages, Application application, @NonNull Callback callback) {
         this.callback = callback;
         if (messages != null) {
             if (messages.size() > 0) {
@@ -49,6 +54,7 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             mResults.addAll(messages);
             notifyItemRangeInserted(0, messages.size() - 1);
         }
+        showOriginalTranscriptionMsg = application.getSharedPreferences("default", Context.MODE_PRIVATE).getBoolean("ShowOriginalTranscriptionMsgPreference", false);
     }
 
     @NonNull
@@ -165,6 +171,9 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         ReceivedHolder(LayoutInflater inflater, ViewGroup parent) {
             super(inflater.inflate(R.layout.component_message_received, parent, false));
             originalTextToBeTranslated = itemView.findViewById(R.id.original_text_to_be_translated);
+            if (!showOriginalTranscriptionMsg) {
+                originalTextToBeTranslated.setVisibility(View.GONE);
+            }
             text = itemView.findViewById(R.id.text_content);
 
             containerSender = itemView.findViewById(R.id.sender_container);
@@ -189,6 +198,9 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         SendHolder(LayoutInflater inflater, ViewGroup parent) {
             super(inflater.inflate(R.layout.component_message_send, parent, false));
             originalTextToBeTranslated = itemView.findViewById(R.id.original_text_to_be_translated);
+            if (!showOriginalTranscriptionMsg) {
+                originalTextToBeTranslated.setVisibility(View.GONE);
+            }
             text = itemView.findViewById(R.id.text);
             card = itemView.findViewById(R.id.card);
         }

--- a/app/src/main/java/nie/translator/rtranslator/tools/gui/messages/MessagesAdapter.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/gui/messages/MessagesAdapter.java
@@ -73,7 +73,7 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 ((ReceivedHolder) holder).sender.setText(message.getMessage().getSender().getName());
                 Log.d("recyclerview", "RecyclerView bind sender");
             }
-            ((MessageHolder) holder).setText(message.getMessage().getText());
+            ((MessageHolder) holder).setText(message.getMessage().getTextToTranslate(), message.getMessage().getText());
             Log.d("recyclerview", "RecyclerView bind text");
             //holder.itemView.requestLayout();
         }
@@ -156,6 +156,7 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     /** The layout for each item in the RecicleView list*/
     private static class ReceivedHolder extends RecyclerView.ViewHolder implements MessageHolder {
+        TextView originalTextToBeTranslated;
         TextView text;
         LinearLayout containerSender;
         TextView textSender;
@@ -163,6 +164,7 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
         ReceivedHolder(LayoutInflater inflater, ViewGroup parent) {
             super(inflater.inflate(R.layout.component_message_received, parent, false));
+            originalTextToBeTranslated = itemView.findViewById(R.id.original_text_to_be_translated);
             text = itemView.findViewById(R.id.text_content);
 
             containerSender = itemView.findViewById(R.id.sender_container);
@@ -171,31 +173,35 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         }
 
         @Override
-        public void setText(String text) {
+        public void setText(String originalTextToBeTranslated, String text) {
             this.textSender.setText(text);
+            this.originalTextToBeTranslated.setText(originalTextToBeTranslated);
             this.text.setText(text);
         }
     }
 
     /** The layout for each item in the RecicleView list*/
     private static class SendHolder extends RecyclerView.ViewHolder implements MessageHolder {
+        TextView originalTextToBeTranslated;
         TextView text;
         CardView card;
 
         SendHolder(LayoutInflater inflater, ViewGroup parent) {
             super(inflater.inflate(R.layout.component_message_send, parent, false));
+            originalTextToBeTranslated = itemView.findViewById(R.id.original_text_to_be_translated);
             text = itemView.findViewById(R.id.text);
             card = itemView.findViewById(R.id.card);
         }
 
         @Override
-        public void setText(String text) {
+        public void setText(String originalTextToBeTranslated, String text) {
+            this.originalTextToBeTranslated.setText(originalTextToBeTranslated);
             this.text.setText(text);
         }
     }
 
     interface MessageHolder {
-        void setText(String text);
+        void setText(String originalTextToBeTranslated, String text);
     }
 
     public interface Callback {

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/main/ConversationMainFragment.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/main/ConversationMainFragment.java
@@ -286,7 +286,7 @@ public class ConversationMainFragment extends VoiceTranslationFragment {
             public void onSuccess(ArrayList<GuiMessage> messages, boolean isMicMute, boolean isAudioMute, boolean isTTSError, final boolean isEditTextOpen, boolean isBluetoothHeadsetConnected, boolean isMicAutomatic, boolean isMicActivated, int listeningMic) {
                 container.setVisibility(View.VISIBLE);
                 // initialization with service values
-                mAdapter = new MessagesAdapter(messages, new MessagesAdapter.Callback() {
+                mAdapter = new MessagesAdapter(messages, global, new MessagesAdapter.Callback() {
                     @Override
                     public void onFirstItemAdded() {
                         description.setVisibility(View.GONE);

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_text_translation/TranslationFragment.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_text_translation/TranslationFragment.java
@@ -229,7 +229,7 @@ public class TranslationFragment extends Fragment {
         });
         translateListener = new Translator.TranslateListener() {
             @Override
-            public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
+            public void onTranslatedText(String textToTranslate, String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
                 outputText.setText(text);
                 if(isFinal){
                     activateTranslationButton();

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieFragment.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieFragment.java
@@ -367,7 +367,7 @@ public class WalkieTalkieFragment extends VoiceTranslationFragment {
             public void onSuccess(ArrayList<GuiMessage> messages, boolean isMicMute, boolean isAudioMute, boolean isTTSError, final boolean isEditTextOpen, boolean isBluetoothHeadsetConnected, boolean isMicAutomatic, boolean isMicActivated, int listeningMic) {
                 // initialization with service values
                 //container.setVisibility(View.VISIBLE);
-                mAdapter = new MessagesAdapter(messages, new MessagesAdapter.Callback() {
+                mAdapter = new MessagesAdapter(messages, global, new MessagesAdapter.Callback() {
                     @Override
                     public void onFirstItemAdded() {
                         description.setVisibility(View.GONE);

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieService.java
@@ -289,14 +289,14 @@ public class WalkieTalkieService extends VoiceTranslationService {
         };
         firstResultTranslateListener = new Translator.TranslateListener() {
             @Override
-            public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
+            public void onTranslatedText(String textToTranslate, String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
                 ((Global) getApplication()).getTTSLanguages(true, new Global.GetLocalesListListener() {
                     @Override
                     public void onSuccess(ArrayList<CustomLocale> ttsLanguages) {
                         if(isFinal && CustomLocale.containsLanguage(ttsLanguages, languageOfText)) { // check if the text can be speak
                             speak(text, languageOfText);
                         }
-                        GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, true, isFinal);
+                        GuiMessage message = new GuiMessage(new Message(textToTranslate, WalkieTalkieService.this, text), resultID, true, isFinal);
                         WalkieTalkieService.super.notifyMessage(message);
                         // we save every new message in the exchanged messages so that the fragment can restore them
                         WalkieTalkieService.super.addOrUpdateMessage(message);
@@ -309,7 +309,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
 
                     @Override
                     public void onFailure(int[] reasons, long value) {
-                        GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, true, isFinal);
+                        GuiMessage message = new GuiMessage(new Message(textToTranslate, WalkieTalkieService.this, text), resultID, true, isFinal);
                         WalkieTalkieService.super.notifyMessage(message);
                         // we save every new message in the exchanged messages so that the fragment can restore them
                         WalkieTalkieService.super.addOrUpdateMessage(message);
@@ -332,14 +332,14 @@ public class WalkieTalkieService extends VoiceTranslationService {
         };
         secondResultTranslateListener = new Translator.TranslateListener() {
             @Override
-            public void onTranslatedText(String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
+            public void onTranslatedText(String textToTranslate, String text, long resultID, boolean isFinal, CustomLocale languageOfText) {
                 ((Global) getApplication()).getTTSLanguages(true, new Global.GetLocalesListListener() {
                     @Override
                     public void onSuccess(ArrayList<CustomLocale> ttsLanguages) {
                         if(isFinal && CustomLocale.containsLanguage(ttsLanguages, languageOfText)) { // check if the text can be speak
                             speak(text, languageOfText);
                         }
-                        GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, false, isFinal);
+                        GuiMessage message = new GuiMessage(new Message(textToTranslate, WalkieTalkieService.this, text), resultID, false, isFinal);
                         WalkieTalkieService.super.notifyMessage(message);
                         // we save every new message in the exchanged messages so that the fragment can restore them
                         WalkieTalkieService.super.addOrUpdateMessage(message);
@@ -352,7 +352,7 @@ public class WalkieTalkieService extends VoiceTranslationService {
 
                     @Override
                     public void onFailure(int[] reasons, long value) {
-                        GuiMessage message = new GuiMessage(new Message(WalkieTalkieService.this, text), resultID, false, isFinal);
+                        GuiMessage message = new GuiMessage(new Message(textToTranslate, WalkieTalkieService.this, text), resultID, false, isFinal);
                         WalkieTalkieService.super.notifyMessage(message);
                         // we save every new message in the exchanged messages so that the fragment can restore them
                         WalkieTalkieService.super.addOrUpdateMessage(message);

--- a/app/src/main/res/layout/component_message_received.xml
+++ b/app/src/main/res/layout/component_message_received.xml
@@ -39,73 +39,96 @@
         app:layout_constraintHorizontal_bias="0.037"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/text_content"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="8dp"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            android:textIsSelectable="true"
-            android:textSize="16sp"
-            android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tool:text="Ciao, come stai?"
-            tool:visibility="gone"/>
-
         <LinearLayout
-            android:id="@+id/sender_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:visibility="gone"
-            tool:visibility="visible">
-
+            android:orientation="vertical">
             <TextView
-                android:id="@+id/text_sender"
-                android:layout_width="match_parent"
+                android:id="@+id/original_text_to_be_translated"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
-                android:layout_marginTop="4dp"
+                android:layout_marginTop="8dp"
                 android:layout_marginEnd="16dp"
-                android:layout_marginBottom="4dp"
-                android:fontFamily="@font/nunito_sans"
-                android:textColor="@color/primary"
-                android:textSize="12sp"
-                android:textStyle="bold"
+                android:layout_marginBottom="8dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                android:textIsSelectable="true"
+                android:textSize="16sp"
+                android:textColor="@color/secondary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tool:text="Original text to be translated"/>
+            <TextView
+                android:id="@+id/text_content"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="8dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                android:textIsSelectable="true"
+                android:textSize="16sp"
+                android:visibility="visible"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0"
-                tool:text="Alice" />
-
-            <TextView
-                android:id="@+id/text_content2"
+                tool:text="Ciao, come stai?"
+                tool:visibility="gone"/>
+            <LinearLayout
+                android:id="@+id/sender_container"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="0dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginBottom="4dp"
-                android:textAppearance="@style/TextAppearance.AppCompat.Large"
-                android:textColor="@color/light_black"
-                android:textIsSelectable="true"
-                android:textSize="16sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_sender"
-                tool:text="Ciao, come stai?"/>
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tool:visibility="visible">
+
+                <TextView
+                    android:id="@+id/text_sender"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="4dp"
+                    android:fontFamily="@font/nunito_sans"
+                    android:textColor="@color/primary"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0"
+                    tool:text="Alice" />
+
+                <TextView
+                    android:id="@+id/text_content2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="0dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="4dp"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                    android:textColor="@color/light_black"
+                    android:textIsSelectable="true"
+                    android:textSize="16sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/text_sender"
+                    tool:text="Ciao, come stai?"/>
+            </LinearLayout>
         </LinearLayout>
+
     </androidx.cardview.widget.CardView>
+
+
 </RelativeLayout>

--- a/app/src/main/res/layout/component_message_send.xml
+++ b/app/src/main/res/layout/component_message_send.xml
@@ -40,23 +40,45 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="1">
-
-        <TextView
-            android:id="@+id/text"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="8dp"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            android:textIsSelectable="true"
-            android:textSize="16sp"
-            android:textColor="@color/black"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tool:text="Ciao, come stai?"/>
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/original_text_to_be_translated"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="8dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                android:textIsSelectable="true"
+                android:textSize="16sp"
+                android:textColor="@color/secondary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tool:text="Original text to be translated"/>
+            <TextView
+                android:id="@+id/text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="8dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                android:textIsSelectable="true"
+                android:textSize="16sp"
+                android:textColor="@color/black"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tool:text="Ciao, come stai?"/>
+        </LinearLayout>
+
     </androidx.cardview.widget.CardView>
 </RelativeLayout>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -146,6 +146,8 @@
 
     <string name="preference_description_mic_sensitivity">Seleziona il livello di volume che serve per avviare e mantenere il riconoscimento vocale</string>
     <string name="preference_description_languages_quality">Permette di supportare anche le lingue che hanno una bassa qualità di traduzione o del riconoscimento vocale</string>
+    <string name="preference_title_show_original_transcription">Mostra le trascrizioni originali oltre la traduzione</string>
+    <string name="preference_description_show_original_transcription_msg_preference">Consente di mostrare la trascrizione originale oltre la traduzione del messaggio.</string>
     <string name="preference_description_support_tts_quality">Permette di supportare anche le lingue che hanno una bassa qualità del sintetizzatore vocale</string>
     <string name="preference_description_tts">Impostazioni di sistema del tts, un eventuale cambio del motore predefinito sarà applicato solo dopo il riavvio dell\'app</string>
     <string name="preference_description_speech_timeout">Seleziona il tempo che deve trascorrere dopo aver smesso di parlare per inviare il testo trascritto</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -132,6 +132,8 @@
 
     <string name="preference_description_mic_sensitivity">Виберіть рівень гучності, який вам потрібно для запуску та підтримки розпізнавання голосу</string>
     <string name="preference_description_languages_quality">Це дозволяє також підтримувати мови, які мають низьку якість перекладу або розпізнавання мовлення</string>
+    <string name="preference_title_show_original_transcription">Показати оригінальні транскрипції крім перекладу</string>
+    <string name="preference_description_show_original_transcription_msg_preference">Це дозволяє показувати оригінальну транскрипцію крім перекладу повідомлення.</string>
     <string name="preference_description_support_tts_quality">Це дозволяє також підтримувати мови, які мають низькое якість синтезу мовлення</string>
     <string name="preference_description_tts">Системні налаштування tts, будь-яка зміна вибраного двигуна буде застосована лише після перезапуску додатка</string>
     <string name="preference_description_speech_timeout">Виберіть час, після якого ви перестаєте говорити, щоб надіслати транскрибований текст</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -130,6 +130,8 @@
 
     <string name="preference_description_mic_sensitivity">选择您需要的音量级别以启动和维持语音识别</string>
     <string name="preference_description_languages_quality">它还允许支持翻译或语音识别质量较低的语言</string>
+    <string name="preference_title_show_original_transcription">显示翻译之外的原始转录内容</string>
+    <string name="preference_description_show_original_transcription_msg_preference">它允许显示消息翻译之外的原始转录内容。</string>
     <string name="preference_description_support_tts_quality">此选项允许支持语音合成器质量较低的语言</string>
     <string name="preference_description_tts">TTS 的系统设定，优先引擎的变更将仅在重新启动应用程序后生效</string>
     <string name="preference_description_speech_timeout">选择您停止说话后发送转录文字的时间</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -129,6 +129,8 @@
 
     <string name="preference_description_mic_sensitivity">選擇您需要的音量級別以啟動和維持語音辨識</string>
     <string name="preference_description_languages_quality">它還允許支援翻譯或語音識別品質較低的語言</string>
+    <string name="preference_title_show_original_transcription">顯示翻譯之外的原始轉錄內容</string>
+    <string name="preference_description_show_original_transcription_msg_preference">它允許顯示消息翻譯之外的原始轉錄內容。</string>
     <string name="preference_description_support_tts_quality">此選項允許支持語音合成器品質較低的語言</string>
     <string name="preference_description_tts">TTS 的系統設定，優先引擎的變更將僅在重新啟動應用程式後生效</string>
     <string name="preference_description_speech_timeout">選擇您停止說話後發送轉錄文字的時間</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -129,6 +129,8 @@
 
     <string name="preference_description_mic_sensitivity">選擇您需要的音量級別以啟動和維持語音辨識</string>
     <string name="preference_description_languages_quality">它還允許支援翻譯或語音識別品質較低的語言</string>
+    <string name="preference_title_show_original_transcription">顯示翻譯之外的原始轉錄內容</string>
+    <string name="preference_description_show_original_transcription_msg_preference">它允許顯示消息翻譯之外的原始轉錄內容。</string>
     <string name="preference_description_support_tts_quality">此選項允許支持語音合成器品質較低的語言</string>
     <string name="preference_description_tts">TTS 的系統設定，優先引擎的變更將僅在重新啟動應用程式後生效</string>
     <string name="preference_description_speech_timeout">選擇您停止說話後發送轉錄文字的時間</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -131,6 +131,8 @@
 
     <string name="preference_description_mic_sensitivity">选择您需要的音量级别以启动和维持语音识别</string>
     <string name="preference_description_languages_quality">它还允许支持翻译或语音识别质量较低的语言</string>
+    <string name="preference_title_show_original_transcription">显示翻译之外的原始转录内容</string>
+    <string name="preference_description_show_original_transcription_msg_preference">它允许显示消息翻译之外的原始转录内容。</string>
     <string name="preference_description_support_tts_quality">此选项允许支持语音合成器质量较低的语言</string>
     <string name="preference_description_tts">TTS 的系统设定，优先引擎的变更将仅在重新启动应用程序后生效</string>
     <string name="preference_description_speech_timeout">选择您停止说话后发送转录文字的时间</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
 
     <string name="preference_title_mic_sensitivity">Microphone sensitivity</string>
     <string name="preference_title_languages_quality">Support low quality languages</string>
+    <string name="preference_title_show_original_transcription">Show original transcriptions beyond the translation</string>
     <string name="preference_title_support_tts_quality">Support languages with low quality tts</string>
     <string name="preference_title_language">Personal language</string>
     <string name="preference_title_tts">Text to speech</string>
@@ -149,6 +150,7 @@
 
     <string name="preference_description_mic_sensitivity">Select the volume level you need to start and maintain voice recognition</string>
     <string name="preference_description_languages_quality">It allow to also supports languages that have low translation or speech recognition quality</string>
+    <string name="preference_description_show_original_transcription_msg_preference">It allows to show the original transcription beyond the translation of the message.</string>
     <string name="preference_description_support_tts_quality">It allow to also supports languages that have a low quality speech synthesizer</string>
     <string name="preference_description_tts">System settings of tts, an eventual change of the preferred engine will be applied only after the restart of the app</string>
     <string name="preference_description_speech_timeout">Select the time after you stop talking to send the transcribed text</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -79,6 +79,12 @@
         android:title="@string/preference_header_advanced"
         app:iconSpaceReserved="false"
         app:allowDividerAbove="true">
+        <nie.translator.rtranslator.settings.ShowOriginalTranscriptionMsgPreference
+            android:defaultValue="false"
+            android:key="ShowOriginalTranscriptionMsgPreference"
+            android:title="@string/preference_title_show_original_transcription"
+            android:summary="@string/preference_description_show_original_transcription_msg_preference"
+            app:iconSpaceReserved="false" />
         <nie.translator.rtranslator.settings.SeekBarPreference
             android:key="BeamSizeSetting"
             android:layout="@layout/preference_seekbar"


### PR DESCRIPTION
- [x] Read and followed the [contribution guidelines](https://github.com/niedev/RTranslator/blob/v2.00/CONTRIBUTING.md)

### Summary

Add a toggle in the settings to enable or disable this feature showing original transcriptions beyond the translation.
Implement the feature showing both the original text and translated text in WalkieTalkie and Conversation Mode. So the user can verify if their speeches are recognized correctly.

### Details

Add a toggle in the settings to enable or disable this feature showing original transcriptions beyond the translation.
Implement the feature showing both the original text and translated text in WalkieTalkie and Conversation Mode. So the user can verify if their speeches are recognized correctly.
![1d4cc976-4a01-44e3-ad32-f1e892bb9420](https://github.com/user-attachments/assets/687a7a52-9ff3-4f90-aefa-f4746103afea)


