### PR TITLE
feat: add replay TTS audio button in WalkieTalkie and Conversation modes

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="23" />
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,13 +6,14 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="corretto-23" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="corretto-23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/nie/translator/rtranslator/tools/ImageActivity.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/ImageActivity.java
@@ -58,6 +58,10 @@ public class ImageActivity extends Activity {
             public void onFirstItemAdded() {
                 mRecyclerView.setVisibility(View.VISIBLE);
             }
+            @Override
+            public void onPlayAudio(GuiMessage message, android.widget.ImageView icon) {
+                // Do nothing for ImageActivity
+            }
         });
         mRecyclerView.setAdapter(mAdapter);
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);

--- a/app/src/main/java/nie/translator/rtranslator/tools/gui/messages/MessagesAdapter.java
+++ b/app/src/main/java/nie/translator/rtranslator/tools/gui/messages/MessagesAdapter.java
@@ -72,7 +72,7 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof MessageHolder) {
-            GuiMessage message = mResults.get(position);
+            final GuiMessage message = mResults.get(position);
             if (holder instanceof ReceivedHolder && message.getMessage().getSender() != null) {
                 ((ReceivedHolder) holder).text.setVisibility(View.GONE);
                 ((ReceivedHolder) holder).containerSender.setVisibility(View.VISIBLE);
@@ -82,6 +82,24 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             ((MessageHolder) holder).setText(message.getMessage().getTextToTranslate(), message.getMessage().getText());
             Log.d("recyclerview", "RecyclerView bind text");
             //holder.itemView.requestLayout();
+            
+            // Bind audio playback listener
+            View.OnClickListener playListener = new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (callback != null && v instanceof android.widget.ImageView) {
+                        callback.onPlayAudio(message, (android.widget.ImageView) v);
+                    }
+                }
+            };
+            View ttsBtnSend = holder.itemView.findViewById(R.id.tts_button);
+            if(ttsBtnSend != null) ttsBtnSend.setOnClickListener(playListener);
+
+            View ttsBtnRecv = holder.itemView.findViewById(R.id.tts_button_content);
+            if(ttsBtnRecv != null) ttsBtnRecv.setOnClickListener(playListener);
+
+            View ttsBtnRecv2 = holder.itemView.findViewById(R.id.tts_button_content2);
+            if(ttsBtnRecv2 != null) ttsBtnRecv2.setOnClickListener(playListener);
         }
     }
 
@@ -218,5 +236,6 @@ public class MessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     public interface Callback {
         void onFirstItemAdded();
+        void onPlayAudio(GuiMessage message, android.widget.ImageView icon);
     }
 }

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/VoiceTranslationService.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/VoiceTranslationService.java
@@ -56,7 +56,10 @@ public abstract class VoiceTranslationService extends GeneralService {
     public static final int STOP_SOUND = 3;
     public static final int SET_EDIT_TEXT_OPEN = 7;
     public static final int RECEIVE_TEXT = 4;
+    public static final int SPEAK_TEXT = 18;
+    public static final int STOP_SPEAKING_TEXT = 19;
     // callbacks
+    public static final int ON_TTS_DONE = 21;
     public static final int ON_ATTRIBUTES = 5;
     public static final int ON_VOICE_STARTED = 0;
     public static final int ON_VOICE_ENDED = 1;
@@ -148,6 +151,7 @@ public abstract class VoiceTranslationService extends GeneralService {
                         }, 500);  //4000
                     }
                 }
+                notifyTTSDone(s);
             }
 
             @Override
@@ -257,6 +261,10 @@ public abstract class VoiceTranslationService extends GeneralService {
     // tts
 
     public synchronized void speak(String result, CustomLocale language) {
+        speak(result, language, null);
+    }
+
+    public synchronized void speak(String result, CustomLocale language, String id) {
         synchronized (mLock) {
             if (tts != null && tts.isActive() && !isAudioMute) {
                 utterancesCurrentlySpeaking++;
@@ -264,11 +272,14 @@ public abstract class VoiceTranslationService extends GeneralService {
                     stopVoiceRecorder();
                     notifyMicDeactivated();   // we notify the client
                 }
+                if (id == null) {
+                    id = String.valueOf(System.currentTimeMillis());
+                }
                 if (tts.getVoice() != null && language.equals(new CustomLocale(tts.getVoice().getLocale()))) {
-                    tts.speak(result, TextToSpeech.QUEUE_ADD, null, "c01");
+                    tts.speak(result, TextToSpeech.QUEUE_ADD, null, id);
                 } else {
                     tts.setLanguage(language,this);
-                    tts.speak(result, TextToSpeech.QUEUE_ADD, null, "c01");
+                    tts.speak(result, TextToSpeech.QUEUE_ADD, null, id);
                 }
             }
         }
@@ -427,6 +438,19 @@ public abstract class VoiceTranslationService extends GeneralService {
                 case SET_EDIT_TEXT_OPEN:
                     isEditTextOpen = data.getBoolean("value");
                     return true;
+                case SPEAK_TEXT:
+                    speak(data.getString("text"), nie.translator.rtranslator.tools.CustomLocale.getInstance(data.getString("languageCode")), data.getString("utteranceId"));
+                    return true;
+                case STOP_SPEAKING_TEXT:
+                    if (tts != null) {
+                        tts.stop();
+                        // Force reset audio listening state
+                        if (utterancesCurrentlySpeaking > 0) {
+                             utterancesCurrentlySpeaking = 0;
+                             ttsListener.onDone(""); 
+                        }
+                    }
+                    return true;
                 case GET_ATTRIBUTES:
                     Bundle bundle = new Bundle();
                     bundle.putInt("callback", ON_ATTRIBUTES);
@@ -517,6 +541,14 @@ public abstract class VoiceTranslationService extends GeneralService {
     }
 
     // connection with clients
+    protected void notifyTTSDone(String utteranceId) {
+        Bundle bundle = new Bundle();
+        bundle.clear();
+        bundle.putInt("callback", ON_TTS_DONE);
+        bundle.putString("utteranceId", utteranceId);
+        super.notifyToClient(bundle);
+    }
+
     public static abstract class VoiceTranslationServiceCommunicator extends ServiceCommunicator {
         private ArrayList<VoiceTranslationServiceCallback> clientCallbacks = new ArrayList<>();
         private ArrayList<AttributesListener> attributesListeners = new ArrayList<>();
@@ -572,6 +604,13 @@ public abstract class VoiceTranslationService extends GeneralService {
                     case ON_MIC_DEACTIVATED: {
                         for (int i = 0; i < clientCallbacks.size(); i++){
                             clientCallbacks.get(i).onMicDeactivated();
+                        }
+                        return true;
+                    }
+                    case ON_TTS_DONE: {
+                        String utteranceId = data.getString("utteranceId");
+                        for (int i = 0; i < clientCallbacks.size(); i++) {
+                            clientCallbacks.get(i).onTTSDone(utteranceId);
                         }
                         return true;
                     }
@@ -667,6 +706,21 @@ public abstract class VoiceTranslationService extends GeneralService {
             super.sendToService(bundle);
         }
 
+        public void speakText(String text, String languageCode, String utteranceId) {
+            Bundle bundle = new Bundle();
+            bundle.putInt("command", SPEAK_TEXT);
+            bundle.putString("text", text);
+            bundle.putString("languageCode", languageCode);
+            bundle.putString("utteranceId", utteranceId);
+            super.sendToService(bundle);
+        }
+
+        public void stopSpeakingText() {
+            Bundle bundle = new Bundle();
+            bundle.putInt("command", STOP_SPEAKING_TEXT);
+            super.sendToService(bundle);
+        }
+
         public void addCallback(ServiceCallback callback) {
             clientCallbacks.add((VoiceTranslationServiceCallback) callback);
         }
@@ -682,6 +736,9 @@ public abstract class VoiceTranslationService extends GeneralService {
         }
 
         public void onVoiceEnded() {
+        }
+
+        public void onTTSDone(String utteranceId) {
         }
 
         public void onVolumeLevel(float volumeLevel) {

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/main/ConversationMainFragment.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_conversation_mode/_conversation/main/ConversationMainFragment.java
@@ -69,6 +69,10 @@ public class ConversationMainFragment extends VoiceTranslationFragment {
     //connection
     protected VoiceTranslationService.VoiceTranslationServiceCommunicator conversationServiceCommunicator;
     protected VoiceTranslationService.VoiceTranslationServiceCallback conversationServiceCallback;
+    
+    // tts UI states
+    private android.widget.ImageView currentPlayingIcon = null;
+    private String currentPlayingUtteranceId = null;
 
     public ConversationMainFragment() {
         //an empty constructor is always needed for fragments
@@ -292,6 +296,42 @@ public class ConversationMainFragment extends VoiceTranslationFragment {
                         description.setVisibility(View.GONE);
                         mRecyclerView.setVisibility(View.VISIBLE);
                     }
+
+                    @Override
+                    public void onPlayAudio(final GuiMessage message, final android.widget.ImageView icon) {
+                        if (icon.getTag() != null && ((int) icon.getTag()) == R.drawable.stop_icon) {
+                            conversationServiceCommunicator.stopSpeakingText();
+                            icon.setImageResource(R.drawable.sound_icon);
+                            icon.setTag(R.drawable.sound_icon);
+                            currentPlayingIcon = null;
+                            currentPlayingUtteranceId = null;
+                            return;
+                        }
+
+                        if (currentPlayingIcon != null) {
+                            currentPlayingIcon.setImageResource(R.drawable.sound_icon);
+                            currentPlayingIcon.setTag(R.drawable.sound_icon);
+                            conversationServiceCommunicator.stopSpeakingText();
+                        }
+
+                        icon.setImageResource(R.drawable.stop_icon);
+                        icon.setTag(R.drawable.stop_icon);
+                        currentPlayingIcon = icon;
+
+                        final String textToSpeak = message.getMessage().getText();
+                        final String utteranceId = String.valueOf(System.currentTimeMillis());
+                        currentPlayingUtteranceId = utteranceId;
+
+                        global.getFirstAndSecondLanguages(true, new nie.translator.rtranslator.Global.GetTwoLocaleListener() {
+                            @Override
+                            public void onSuccess(nie.translator.rtranslator.tools.CustomLocale language1, nie.translator.rtranslator.tools.CustomLocale language2) {
+                                String localeCode = message.isMine() ? language2.getCode() : language1.getCode();
+                                conversationServiceCommunicator.speakText(textToSpeak, localeCode, utteranceId);
+                            }
+                            @Override
+                            public void onFailure(int[] reasons, long value) {}
+                        });
+                    }
                 });
                 mRecyclerView.setAdapter(mAdapter);
                 // restore microphone and sound status
@@ -435,6 +475,19 @@ public class ConversationMainFragment extends VoiceTranslationFragment {
 
 
     public class ConversationServiceCallback extends VoiceTranslationService.VoiceTranslationServiceCallback {
+        @Override
+        public void onTTSDone(String utteranceId) {
+            super.onTTSDone(utteranceId);
+            if (utteranceId != null && utteranceId.equals(currentPlayingUtteranceId)) {
+                if (currentPlayingIcon != null) {
+                    currentPlayingIcon.setImageResource(R.drawable.sound_icon);
+                    currentPlayingIcon.setTag(R.drawable.sound_icon);
+                    currentPlayingIcon = null;
+                }
+                currentPlayingUtteranceId = null;
+            }
+        }
+
         @Override
         public void onVoiceStarted(int mode) {
             super.onVoiceStarted(mode);

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieFragment.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/_walkie_talkie_mode/_walkie_talkie/WalkieTalkieFragment.java
@@ -84,6 +84,10 @@ public class WalkieTalkieFragment extends VoiceTranslationFragment {
     //connection
     protected WalkieTalkieService.WalkieTalkieServiceCommunicator walkieTalkieServiceCommunicator;
     protected VoiceTranslationService.VoiceTranslationServiceCallback walkieTalkieServiceCallback;
+    
+    // tts UI states
+    private android.widget.ImageView currentPlayingIcon = null;
+    private String currentPlayingUtteranceId = null;
 
     //languageListDialog
     private LanguageListAdapter listView;
@@ -372,6 +376,42 @@ public class WalkieTalkieFragment extends VoiceTranslationFragment {
                     public void onFirstItemAdded() {
                         description.setVisibility(View.GONE);
                         mRecyclerView.setVisibility(View.VISIBLE);
+                    }
+
+                    @Override
+                    public void onPlayAudio(final GuiMessage message, final android.widget.ImageView icon) {
+                        if (icon.getTag() != null && ((int) icon.getTag()) == R.drawable.stop_icon) {
+                            walkieTalkieServiceCommunicator.stopSpeakingText();
+                            icon.setImageResource(R.drawable.sound_icon);
+                            icon.setTag(R.drawable.sound_icon);
+                            currentPlayingIcon = null;
+                            currentPlayingUtteranceId = null;
+                            return;
+                        }
+
+                        if (currentPlayingIcon != null) {
+                            currentPlayingIcon.setImageResource(R.drawable.sound_icon);
+                            currentPlayingIcon.setTag(R.drawable.sound_icon);
+                            walkieTalkieServiceCommunicator.stopSpeakingText();
+                        }
+
+                        icon.setImageResource(R.drawable.stop_icon);
+                        icon.setTag(R.drawable.stop_icon);
+                        currentPlayingIcon = icon;
+                        
+                        final String textToSpeak = message.getMessage().getText();
+                        final String utteranceId = String.valueOf(System.currentTimeMillis());
+                        currentPlayingUtteranceId = utteranceId;
+
+                        global.getFirstAndSecondLanguages(true, new Global.GetTwoLocaleListener() {
+                            @Override
+                            public void onSuccess(nie.translator.rtranslator.tools.CustomLocale language1, nie.translator.rtranslator.tools.CustomLocale language2) {
+                                String localeCode = message.isMine() ? language2.getCode() : language1.getCode();
+                                walkieTalkieServiceCommunicator.speakText(textToSpeak, localeCode, utteranceId);
+                            }
+                            @Override
+                            public void onFailure(int[] reasons, long value) {}
+                        });
                     }
                 });
                 mRecyclerView.setAdapter(mAdapter);
@@ -693,6 +733,19 @@ public class WalkieTalkieFragment extends VoiceTranslationFragment {
 
 
     public class WalkieTalkieServiceCallback extends VoiceTranslationService.VoiceTranslationServiceCallback {
+        @Override
+        public void onTTSDone(String utteranceId) {
+            super.onTTSDone(utteranceId);
+            if (utteranceId != null && utteranceId.equals(currentPlayingUtteranceId)) {
+                if (currentPlayingIcon != null) {
+                    currentPlayingIcon.setImageResource(R.drawable.sound_icon);
+                    currentPlayingIcon.setTag(R.drawable.sound_icon);
+                    currentPlayingIcon = null;
+                }
+                currentPlayingUtteranceId = null;
+            }
+        }
+
         @Override
         public void onVoiceStarted(int mode) {
             super.onVoiceStarted(mode);

--- a/app/src/main/res/layout/component_message_received.xml
+++ b/app/src/main/res/layout/component_message_received.xml
@@ -60,25 +60,43 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 tool:text="Original text to be translated"/>
-            <TextView
-                android:id="@+id/text_content"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginBottom="8dp"
-                android:textAppearance="@style/TextAppearance.AppCompat.Large"
-                android:textIsSelectable="true"
-                android:textSize="16sp"
-                android:visibility="visible"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tool:text="Ciao, come stai?"
-                tool:visibility="gone"/>
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+                <TextView
+                    android:id="@+id/text_content"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="8dp"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                    android:textIsSelectable="true"
+                    android:textSize="16sp"
+                    android:visibility="visible"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tool:text="Ciao, come stai?"
+                    tool:visibility="gone"/>
+                <ImageView
+                    android:id="@+id/tts_button_content"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginEnd="12dp"
+                    android:layout_marginStart="0dp"
+                    android:src="@drawable/sound_icon"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:focusable="true"
+                    app:tint="@color/primary"/>
+            </LinearLayout>
             <LinearLayout
                 android:id="@+id/sender_container"
                 android:layout_width="match_parent"
@@ -107,24 +125,42 @@
                     app:layout_constraintVertical_bias="0"
                     tool:text="Alice" />
 
-                <TextView
-                    android:id="@+id/text_content2"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="0dp"
-                    android:layout_marginEnd="16dp"
-                    android:layout_marginBottom="4dp"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Large"
-                    android:textColor="@color/light_black"
-                    android:textIsSelectable="true"
-                    android:textSize="16sp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/text_sender"
-                    tool:text="Ciao, come stai?"/>
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+                    <TextView
+                        android:id="@+id/text_content2"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginTop="0dp"
+                        android:layout_marginEnd="16dp"
+                        android:layout_marginBottom="4dp"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                        android:textColor="@color/light_black"
+                        android:textIsSelectable="true"
+                        android:textSize="16sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/text_sender"
+                        tool:text="Ciao, come stai?"/>
+                    <ImageView
+                        android:id="@+id/tts_button_content2"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginEnd="12dp"
+                        android:layout_marginStart="0dp"
+                        android:src="@drawable/sound_icon"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:clickable="true"
+                        android:focusable="true"
+                        app:tint="@color/primary"/>
+                </LinearLayout>
             </LinearLayout>
         </LinearLayout>
 

--- a/app/src/main/res/layout/component_message_send.xml
+++ b/app/src/main/res/layout/component_message_send.xml
@@ -61,23 +61,41 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 tool:text="Original text to be translated"/>
-            <TextView
-                android:id="@+id/text"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginBottom="8dp"
-                android:textAppearance="@style/TextAppearance.AppCompat.Large"
-                android:textIsSelectable="true"
-                android:textSize="16sp"
-                android:textColor="@color/black"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tool:text="Ciao, come stai?"/>
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+                <TextView
+                    android:id="@+id/text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="8dp"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                    android:textIsSelectable="true"
+                    android:textSize="16sp"
+                    android:textColor="@color/black"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tool:text="Ciao, come stai?"/>
+                <ImageView
+                    android:id="@+id/tts_button"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginEnd="12dp"
+                    android:layout_marginStart="0dp"
+                    android:src="@drawable/sound_icon"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:focusable="true"
+                    app:tint="@color/primary"/>
+            </LinearLayout>
         </LinearLayout>
 
     </androidx.cardview.widget.CardView>

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@
 # org.gradle.parallel=true
 #Wed Jun 05 15:24:01 CEST 2024
 android.debug.obsoleteApi=true
-android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Mar 27 12:07:22 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip


### PR DESCRIPTION
- [x] Read and followed the [contribution guidelines](https://github.com/niedev/RTranslator/blob/v2.00/CONTRIBUTING.md)

### Summary

Implemented manual TTS playback functionality for both WalkieTalkie and Conversation modes, allowing users to conveniently replay translated messages via a speaker icon. Integrated a precise cross-process `onTTSDone` callback mechanism for accurate UI state synchronization.

### Details

- **UI Enhancements**: Added a speaker icon to each message bubble in `WalkieTalkie` and `Conversation` modes. Tweaked text containers with `layout_weight="1"` in `component_message_send.xml` and `component_message_received.xml` to prevent long translated texts from overlapping the icon.
- **Precise IPC Callback**: Introduced a new ON_TTS_DONE command in VoiceTranslationService. This implements a highly accurate native UtteranceProgressListener.onDone event propagation to keep the UI perfectly synchronized with the audio playback state.
- **Utterance ID Tracking**: Updated `VoiceTranslationServiceCommunicator` to attach a unique `utteranceId` (timestamp-based) during `speakText` calls. The UI correctly identifies the finished playback and resets the stop icon back to the play icon.
- **Backward Compatibility**: Maintained system stability by providing a default empty implementation of `onTTSDone` in the base `VoiceTranslationServiceCallback`, and safely overloaded the `speak()` method to prevent breaking existing auto-translation logic in `WalkieTalkieService` and `ConversationService`.

### Other

_None_
