### PR TITLE
Fix phone freeze during model download — cursor leaks in Downloader

### DIFF
--- a/app/src/main/java/nie/translator/rtranslator/access/DownloadFragment.java
+++ b/app/src/main/java/nie/translator/rtranslator/access/DownloadFragment.java
@@ -207,11 +207,24 @@ public class DownloadFragment extends Fragment {
                             if(downloadErrorText.getVisibility() == View.GONE && transferErrorText.getVisibility() == View.GONE && retryButton.getVisibility() == View.GONE && getContext() != null) {
                                 boolean error = checkDownloadOrTransferErrors(false); //we check and show eventual errors in the download or transfer of the models
                                 if (!error) {
-                                    //we update the Gui according to the downloads status
+                                    //we compute progress in background thread (avoids DownloadManager query on main thread)
+                                    int progress = downloader.getDownloadProgress(progressBar.getMax());
+                                    //we compute the total size for the numbers display
+                                    float totalSize = 0;
+                                    for (int i = 0; i < DownloadFragment.DOWNLOAD_SIZES.length; i++) {
+                                        totalSize = totalSize + DownloadFragment.DOWNLOAD_SIZES[i];
+                                    }
+                                    totalSize = totalSize / 1000000;   //convert from Kb to Gb
+
                                     mainHandler.post(() -> {
                                         if(getContext() != null) {
-                                            updateProgress();
-                                            //we update the progressDescriptionText
+                                            //update progressbar with pre-computed value
+                                            progressBar.setProgress(progress, true);
+                                            //update progress numbers
+                                            float downloadedGb = progress * totalSize / progressBar.getMax();
+                                            DecimalFormat decimalFormat = new DecimalFormat("#.##");
+                                            progressNumbersText.setText(decimalFormat.format(downloadedGb) + " / " + decimalFormat.format(totalSize) + " GB");
+                                            //update the progressDescriptionText
                                             SharedPreferences sharedPreferences = global.getSharedPreferences("default", Context.MODE_PRIVATE);
                                             if(NeuralNetworkApi.isVerifying){
                                                 String lastDownloadSuccess = sharedPreferences.getString("lastDownloadSuccess", "");
@@ -261,7 +274,8 @@ public class DownloadFragment extends Fragment {
                             Thread.sleep(INTERVAL_TIME_FOR_GUI_UPDATES_MS);
 
                         } catch (InterruptedException e) {
-                            e.printStackTrace();
+                            Thread.currentThread().interrupt();
+                            break;
                         }
                     }
                 }

--- a/app/src/main/java/nie/translator/rtranslator/access/Downloader.java
+++ b/app/src/main/java/nie/translator/rtranslator/access/Downloader.java
@@ -52,11 +52,16 @@ public class Downloader{
     @Nullable
     public String getUrlFromDownload(long downloadId){
         Cursor result = query(downloadId);
-        int index = result.getColumnIndex(DownloadManager.COLUMN_URI);
-        if(index > 0 && result.moveToFirst() && result.getCount() > 0) {
-            return result.getString(index);
-        }else{
-            return null;
+        try {
+            if (result == null) return null;
+            int index = result.getColumnIndex(DownloadManager.COLUMN_URI);
+            if(index > 0 && result.moveToFirst() && result.getCount() > 0) {
+                return result.getString(index);
+            }else{
+                return null;
+            }
+        } finally {
+            if (result != null) result.close();
         }
     }
 
@@ -65,9 +70,14 @@ public class Downloader{
         long downloadId = sharedPreferences.getLong("currentDownloadId", -1);
         if(downloadId >= 0) {
             Cursor result = query(downloadId);
-            int index = result.getColumnIndex(DownloadManager.COLUMN_STATUS);
-            if (index > 0 && result.moveToFirst() && result.getCount() > 0) {
-                return result.getInt(index);
+            try {
+                if (result == null) return -1;
+                int index = result.getColumnIndex(DownloadManager.COLUMN_STATUS);
+                if (index > 0 && result.moveToFirst() && result.getCount() > 0) {
+                    return result.getInt(index);
+                }
+            } finally {
+                if (result != null) result.close();
             }
         }else if(downloadId == -3){
             return DownloadManager.STATUS_FAILED;
@@ -120,15 +130,18 @@ public class Downloader{
         int currentProgress = 0;
         if(downloadId >= 0) {
             int index = findDownloadUrlIndex(downloadId);
-            if(index != -1 && index != lastDownloadSuccessIndex) {   //we check that the current download is different from the last success download (if they are the same that means that the next download is not started yet)
+            if(index != -1 && index != lastDownloadSuccessIndex) {
                 Cursor result = query(downloadId);
-                int indexBytesDownloaded = result.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR);
-                //int indexBytesTotal = result.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES);
-                if (indexBytesDownloaded > 0 && /*indexBytesTotal>0 &&*/ result.moveToFirst() && result.getCount() > 0) {
-                    int bytesDownloaded = result.getInt(indexBytesDownloaded);
-                    //int bytesTotal = result.getInt(indexBytesTotal);
-                    int kbDownloaded = bytesDownloaded / 1000;
-                    currentProgress = (kbDownloaded * max) / totalSize;       //kbDownloaded : totalSize = x : max   (where x is currentProgress)
+                try {
+                    if (result == null) return baseProgress;
+                    int indexBytesDownloaded = result.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR);
+                    if (indexBytesDownloaded > 0 && result.moveToFirst() && result.getCount() > 0) {
+                        int bytesDownloaded = result.getInt(indexBytesDownloaded);
+                        int kbDownloaded = bytesDownloaded / 1000;
+                        currentProgress = (kbDownloaded * max) / totalSize;
+                    }
+                } finally {
+                    if (result != null) result.close();
                 }
             }
         }

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/neural_networks/NeuralNetworkApi.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/neural_networks/NeuralNetworkApi.java
@@ -30,7 +30,7 @@ import nie.translator.rtranslator.tools.ErrorCodes;
 public class NeuralNetworkApi {
     protected Global global;
     private ArrayList<Thread> pendingThreads= new ArrayList<>();
-    public static boolean isVerifying = false;
+    public static volatile boolean isVerifying = false;
 
     protected void addPendingThread(Thread thread){
         pendingThreads.add(thread);

--- a/app/src/main/java/nie/translator/rtranslator/voice_translation/neural_networks/translation/Translator.java
+++ b/app/src/main/java/nie/translator/rtranslator/voice_translation/neural_networks/translation/Translator.java
@@ -155,8 +155,7 @@ public class Translator extends NeuralNetworkApi {
                     encoderOptions.close();
                     cacheInitOptions.close();
 
-                    //mainHandler.post(() -> initListener.onInitializationFinished());
-                    initListener.onInitializationFinished();
+                    mainHandler.post(() -> initListener.onInitializationFinished());
 
                 } catch (OrtException e) {
                     e.printStackTrace();


### PR DESCRIPTION
Fixes phone freeze during model download (NLLB cache initializer, etc.).

Root cause: Cursor leaks in Downloader.java — 3 methods never closed Cursors from DownloadManager.query(). guiUpdater thread called these every 100ms, exhausting CursorWindow limit in 3-6 seconds.

Changes:
- Downloader.java: try-finally + close() + null-checks on 3 query methods
- DownloadFragment.java: progress computed on BG thread (was on main); InterruptedException now stops thread properly
- NeuralNetworkApi.java: volatile on isVerifying
- Translator.java: onInitializationFinished via mainHandler.post() (was called from BG thread)

Closes #140